### PR TITLE
fix: 공모전 둘러보기 링크 변경

### DIFF
--- a/src/pages/Rending.jsx
+++ b/src/pages/Rending.jsx
@@ -21,7 +21,7 @@ const Rending = () => {
        </Link>
    
     </div>
-    <Link className='text-[#A3A3A3] underline text-sm' to="/main">지금 올라온 공모전 둘러보기</Link>
+    <Link className='text-[#A3A3A3] underline text-sm' to="/participant-main-page">지금 올라온 공모전 둘러보기</Link>
     </div>
     </>
   )


### PR DESCRIPTION
## 작업 개요

- 랜더링페이지에서 지금 진행하는 공모전 둘러보기 클릭시 경로 이동

## 변경 사항

- 경로 변경

## 관련 이슈

- (관련 이슈 번호나 링크를 작성하세요)
