### PR TITLE
Feature/detail-routing : 소상공인 진행중 공모전 카드 클릭 시 상세페이지 이동 기능 추가

### DIFF
--- a/src/main/ProjectList.jsx
+++ b/src/main/ProjectList.jsx
@@ -37,6 +37,7 @@ const ProjectList = ({
   selectedCategories = [],
   selectedBusinesses = [],
   hideHeader = false,
+  role,
 }) => {
   const [page, setPage] = useState(1); // 현재 보고있는 페이지 번호 상태
   const [projects, setProjects] = useState([]);
@@ -143,6 +144,7 @@ const ProjectList = ({
                 project={project}
                 categories={categories}
                 businessTypes={businessTypes}
+                role={role}
               />
             );
           })}

--- a/src/main/projectCard/ProjectCardInProgress.jsx
+++ b/src/main/projectCard/ProjectCardInProgress.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import prizeIcon from "../../assets/prizeIcon.png";
 import participantIcon from "../../assets/participantIcon.png";
 import calendarIcon from "../../assets/calendarIcon.png";
@@ -10,6 +11,7 @@ const ProjectCardInProgress = ({
   project,
   categories = [],
   businessTypes = [],
+  role,
 }) => {
   // categories 배열에서 현재 프로젝트 category(code)와 매칭되는 객체 찾기
   const categoryObj = categories.find((c) => c.code === project.category);
@@ -31,7 +33,8 @@ const ProjectCardInProgress = ({
     return diffDays;
   };
 
-  return (
+  // 카드 내용 (공통)
+  const cardContent = (
     <div className="w-[856px] h-[252px] border border-[#E1E1E1] rounded-[12px] pl-[28px] font-pretendard hover:opacity-60 hover:border-[#A3A3A3]">
       {/* 상단 카테고리/마감일 */}
       <div className="flex gap-[4px] text-[12px] text-[#A3A3A3] font-medium mt-[20px]">
@@ -64,9 +67,7 @@ const ProjectCardInProgress = ({
           </span>
         </div>
 
-        {/* 참여작 
-            -> 추후 백엔드가 참여작 개수 받아올 것 
-        */}
+        {/* 참여작 (임시 값) */}
         <div className="flex items-center gap-2">
           <div className="flex items-center gap-2 w-[60px]">
             <img
@@ -103,6 +104,13 @@ const ProjectCardInProgress = ({
         </span>
       </div>
     </div>
+  );
+
+  // role이 merchant -> 소상공인 공모전 상세 페이지 이동
+  return role === "merchant" ? (
+    <Link to={`/project-detail/${project.projectId}`}>{cardContent}</Link>
+  ) : (
+    cardContent
   );
 };
 

--- a/src/pages/MerchantMainPage.jsx
+++ b/src/pages/MerchantMainPage.jsx
@@ -41,6 +41,7 @@ const MerchantMainPage = () => {
           businessTypes={businessTypes}
           selectedCategories={selectedCategories}
           selectedBusinesses={selectedBusinesses}
+          role="merchant"
         />
       </div>
       <Footer />


### PR DESCRIPTION
## 변경 사항
- ProjectCardInProgress에 role prop 추가 - 소상공인, 참가자 역할 분리
- merchant일 경우 진행중 공모전 카드 클릭 시 `/project-detail/:projectId` 로 이동 가능하게 구현

https://github.com/user-attachments/assets/7520f2a4-d92d-448c-9799-0619a6556c89

