### PR TITLE
Feature/projects merchantcheckpage 소상공인 내 공모전 / API 연동

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,8 +10,9 @@ import Signin from "./pages/Signin";
 import AuthProvider from "./contexts/AuthProvider";
 import ParticipantMainPage from "./pages/ParticipantMainPage";
 import ProjectSubmissionPage from "./pages/ProjectSubmissionPage";
-import MerchantMy from "./pages/MerchantMy";
-import ParticipantMy from "./pages/ParticipantMy.jsx";
+
+import MerchantMyProject from "./pages/MerchantMyProject.jsx";
+import ParticipantMyProject from "./pages/ParticipantMyProject.jsx";
 
 export default function App() {
   return (
@@ -49,8 +50,8 @@ export default function App() {
             path="/projects/:projectId/submission"
             element={<ProjectSubmissionPage />}
           />
-           <Route path="merchant-mypage" element={<MerchantMy/>}/>
-            <Route path="participant-mypage" element={<ParticipantMy/>}/>
+           <Route path="merchant-myproject" element={<MerchantMyProject/>}/>
+            <Route path="participant-myproject" element={<ParticipantMyProject/>}/>
         </Routes>
       </BrowserRouter>
     </AuthProvider>

--- a/src/apis/getProjectsApi.js
+++ b/src/apis/getProjectsApi.js
@@ -1,12 +1,28 @@
+// apis/getProjectsApi.js
 import api from "./api";
 
-// 프로젝트(공모전) 목록 조회 API
+// 전체 목록 (기존)
 export const fetchProjects = async () => {
-  try {
-    const res = await api.get("projects");
-    return res.data;
-  } catch (error) {
-    console.error("프로젝트 목록 조회 실패:", error);
-    throw error;
-  }
+  const res = await api.get("projects");
+  return res.data;
+};
+
+// 내 공모전만 (서버에 mine 파라미터가 있다면 우선 시도하고, 없으면 프론트 필터)
+export const fetchMyProjects = async () => {
+  // 1) 내 정보
+  const meRes = await api.get("/users");
+  const me = meRes.data; // { nickname, role, ... }
+
+  // 2) 서버가 지원하면 이걸로 대체 (주석 해제해서 사용)
+  // const mineRes = await api.get("projects", { params: { mine: true }});
+  // return mineRes.data;
+
+  // 3) 지원 없을 때 프론트에서 필터
+  const all = await fetchProjects();
+  // writerNickname 또는 merchantName 등의 필드에 맞춰 튜닝
+  return all.filter(p =>
+    p.writerNickname === me.nickname ||
+    p.merchantName === me.nickname ||  // 백엔드 필드명에 맞게 추가
+    p.ownerNickname === me.nickname
+  );
 };

--- a/src/components/myprojects/MyProjectRow.jsx
+++ b/src/components/myprojects/MyProjectRow.jsx
@@ -1,0 +1,67 @@
+// src/components/myprojects/MyProjectRow.jsx
+import React from "react";
+import prizeIcon from "../../assets/prizeIcon.png";
+import participantIcon from "../../assets/participantIcon.png";
+import calendarIcon from "../../assets/calendarIcon.png";
+import { formatDate } from "../../utils/dateUtils";
+
+const MyProjectRow = ({ project, getCategoryLabel, getBusinessTypeLabel }) => {
+  const formatCurrency = (amount) => {
+    if (amount == null) return "가격 없음";
+    const numeric = Number(String(amount).replace(/[^0-9]/g, ""));
+    if (Number.isNaN(numeric)) return amount;
+    return numeric.toLocaleString() + "원";
+  };
+
+  const period =
+    project?.createdAt && project?.deadline
+      ? `${formatDate(project.createdAt)} - ${formatDate(project.deadline)}`
+      : "기간 없음";
+
+  return (
+    // ▶ 플랫 스타일: 테두리/라운드 제거, 여백만 최소화
+    <div className="w-full px-4 py-3">
+      {/* ① 카테고리/업종 */}
+      <div className="text-[12px] text-[#8F8F8F]">
+        {getCategoryLabel(project?.category) || "카테고리 없음"}
+        <span className="mx-1.5">·</span>
+        {getBusinessTypeLabel(project?.businessType) || "업종 없음"}
+      </div>
+
+      {/* ② 제목 (줄간격 타이트) */}
+      <h3 className="mt-[2px] text-[16px] font-semibold text-[#212121] leading-[1.2]">
+        {project?.title || "공모전 제목 없음"}
+      </h3>
+
+      {/* ③ 요약 (한 줄, 말줄임표) */}
+      <p className="mt-[2px] text-[12px] text-[#626262] truncate">
+        {project?.summary || "프로젝트 요약 정보가 없습니다."}
+      </p>
+
+      {/* ④ 하단 정보 */}
+      <div className="mt-[10px] space-y-[6px] text-[13px]">
+        <div className="flex items-center gap-[6px]">
+          <img className="w-4 h-4" src={prizeIcon} alt="상금" />
+          <span className="text-[#828282] w-[36px]">상금</span>
+          <span className="font-medium text-[#212121]">
+            {formatCurrency(project?.rewardAmount)}
+          </span>
+        </div>
+        <div className="flex items-center gap-[6px]">
+          <img className="w-4 h-4" src={participantIcon} alt="참여작" />
+          <span className="text-[#828282] w-[36px]">참여작</span>
+          <span className="font-medium text-[#212121]">
+            {project?.submissionsCount ?? 0}개
+          </span>
+        </div>
+        <div className="flex items-center gap-[6px]">
+          <img className="w-4 h-4" src={calendarIcon} alt="기간" />
+          <span className="text-[#828282] w-[36px]">기간</span>
+          <span className="font-medium text-[#212121]">{period}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MyProjectRow;

--- a/src/components/myprojects/MyProjectRow.jsx
+++ b/src/components/myprojects/MyProjectRow.jsx
@@ -19,7 +19,7 @@ const MyProjectRow = ({ project, getCategoryLabel, getBusinessTypeLabel }) => {
       : "기간 없음";
 
   return (
-    // ▶ 플랫 스타일: 테두리/라운드 제거, 여백만 최소화
+  
     <div className="w-full px-4 py-3">
       {/* ① 카테고리/업종 */}
       <div className="text-[12px] text-[#8F8F8F]">

--- a/src/components/myprojects/MyProjectRow.jsx
+++ b/src/components/myprojects/MyProjectRow.jsx
@@ -22,19 +22,19 @@ const MyProjectRow = ({ project, getCategoryLabel, getBusinessTypeLabel }) => {
   
     <div className="w-full px-4 py-3">
       {/* ① 카테고리/업종 */}
-      <div className="text-[12px] text-[#8F8F8F]">
+      <div className="text-[12px] text-[#8F8F8F] ">
         {getCategoryLabel(project?.category) || "카테고리 없음"}
         <span className="mx-1.5">·</span>
         {getBusinessTypeLabel(project?.businessType) || "업종 없음"}
       </div>
 
       {/* ② 제목 (줄간격 타이트) */}
-      <h3 className="mt-[2px] text-[16px] font-semibold text-[#212121] leading-[1.2]">
+      <h3 className="text-[16px] font-semibold text-[#212121] leading-[1.2] mt-[16px]">
         {project?.title || "공모전 제목 없음"}
       </h3>
 
       {/* ③ 요약 (한 줄, 말줄임표) */}
-      <p className="mt-[2px] text-[12px] text-[#626262] truncate">
+      <p className="mt-[8px] text-[12px] text-[#626262] truncate">
         {project?.summary || "프로젝트 요약 정보가 없습니다."}
       </p>
 

--- a/src/header/MerchantHeader.jsx
+++ b/src/header/MerchantHeader.jsx
@@ -59,7 +59,7 @@ const MerchantHeader = ({ defaultValue = "" }) => {
 
       {/* 버튼들 */}
       <div className="flex-1 flex justify-end gap-8">
-        <button onClick={() => navigate("/merchant-mypage")} className="text-[12px] text-[#4C4C4C] font-medium cursor-pointer">
+        <button onClick={() => navigate("/merchant-myproject")} className="text-[12px] text-[#4C4C4C] font-medium cursor-pointer">
           내 공모전
         </button> 
         <Link

--- a/src/header/ParticipantHeader.jsx
+++ b/src/header/ParticipantHeader.jsx
@@ -63,7 +63,7 @@ const ParticipantHeader = ({ defaultValue = "" }) => {
 
       {/* 버튼들 */}
       <div className="flex-1 flex justify-end gap-8">
-         <button onClick={() => navigate("/participant-mypage")} className="text-[12px] text-[#4C4C4C] font-medium cursor-pointer">
+         <button onClick={() => navigate("/participant-myproject")} className="text-[12px] text-[#4C4C4C] font-medium cursor-pointer">
           내 공모전
         </button> 
         <IoPersonCircle className="text-[#B9B9B9] w-[32px] h-[32px] cursor-pointer" />

--- a/src/pages/MerchantMy.jsx
+++ b/src/pages/MerchantMy.jsx
@@ -1,9 +1,0 @@
-import React from 'react'
-
-const Merchantmy = () => {
-  return (
-    <div>Merchantmy</div>
-  )
-}
-
-export default Merchantmy

--- a/src/pages/MerchantMyProject.jsx
+++ b/src/pages/MerchantMyProject.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const MerchantMyProject = () => {
+  return (
+    <div>MerchantMyProject</div>
+  )
+}
+
+export default MerchantMyProject

--- a/src/pages/MerchantMyProject.jsx
+++ b/src/pages/MerchantMyProject.jsx
@@ -1,9 +1,193 @@
-import React from 'react'
+// 시간날때 tailwind 수정해야함
+import React, { useEffect, useMemo, useState } from "react";
+
+
+import MerchantHeader from "../header/MerchantHeader";
+import Footer from "../components/Footer";
+import Pagination from "../components/Pagination";
+
+import { fetchUserInfo } from "../apis/userApi";
+import { fetchProjects } from "../apis/getProjectsApi";
+import { fetchCategories } from "../apis/category";
+import { getBusinessTypes } from "../apis/businessTypes";
+
+import MyProjectRow from "../components/myprojects/MyProjectRow";
+import { useNavigate, Link } from "react-router-dom";
+
+const PAGE_SIZE = 5;
+
+const STATUS_LABEL = {
+  IN_PROGRESS: "진행 중",
+  VOTING: "투표 중",
+  CLOSED: "완료",
+};
 
 const MerchantMyProject = () => {
-  return (
-    <div>MerchantMyProject</div>
-  )
-}
+  const navigate = useNavigate();
 
-export default MerchantMyProject
+  const [me, setMe] = useState(null);
+  const [projects, setProjects] = useState([]);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [categories, setCategories] = useState([]);
+  const [businessTypes, setBusinessTypes] = useState([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const user = await fetchUserInfo();
+        setMe(user);
+
+        if (user?.role && user.role !== "ROLE_BUSINESS") {
+          alert("소상공인 전용 페이지입니다.");
+          navigate("/participant-main-page");
+          return;
+        }
+
+        const [cats, biz] = await Promise.all([
+          fetchCategories(),
+          getBusinessTypes(),
+        ]);
+        setCategories(cats || []);
+        setBusinessTypes(biz || []);
+
+        const all = await fetchProjects();
+        const mine = all.filter(
+          (p) =>
+            p?.writerNickname === user?.nickname ||
+            p?.merchantName === user?.nickname ||
+            p?.ownerNickname === user?.nickname
+        );
+        setProjects(mine);
+      } catch (e) {
+        console.error(e);
+        alert("내 공모전을 불러오는 데 실패했습니다.");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [navigate]);
+
+  const start = (page - 1) * PAGE_SIZE;
+  const pageItems = useMemo(
+    () => projects.slice(start, start + PAGE_SIZE),
+    [projects, start]
+  );
+
+  const getCategoryLabel = (code) =>
+    categories.find((c) => c.code === code)?.description || "카테고리 없음";
+
+  const getBusinessTypeLabel = (code) =>
+    businessTypes.find((b) => b.code === code)?.description || "업종 없음";
+
+  const renderAwardCell = (p) => {
+    const awarded = p.awarded === true || p.winnerSelected === true;
+
+    if (p.status === "CLOSED" && !awarded) {
+      return (
+        <button
+          onClick={() => navigate(`/project-detail/${p.projectId}`)}
+          className="w-[96px] h-[32px] rounded-[6px] bg-[#2FD8F6] hover:bg-[#2AC2DD] text-white text-[12px]"
+        >
+          수상 확정
+        </button>
+      );
+    }
+    if (p.status === "CLOSED" && awarded) {
+      return (
+        <button
+          disabled
+          className="w-[96px] h-[32px] rounded-[6px] bg-[#EDEDED] text-[#A3A3A3] text-[12px] cursor-not-allowed"
+        >
+          거래 완료
+        </button>
+      );
+    }
+    return (
+      <button
+        disabled
+        className="w-[96px] h-[32px] rounded-[6px] bg-[#F3F3F3] text-[#A3A3A3] text-[12px] cursor-not-allowed"
+      >
+        수상 확정
+      </button>
+    );
+  };
+
+  if (loading) return <div className="p-10">불러오는 중...</div>;
+
+  return (
+    <div className="min-h-screen bg-white font-pretendard">
+      <MerchantHeader />
+
+      <div className="flex flex-col items-center w-full">
+        <div className="w-[1120px] max-w-[92vw]">
+          <h2 className="text-[24px] font-semibold mt-[40px] mb-[20px] text-center">
+            내 공모전
+          </h2>
+
+        {/* 헤더: 좌(8) | 상태(2) | 수상작(2) */}
+<div
+  className="grid grid-cols-12 items-center h-[40px] gap-0
+             bg-[#F3F3F3] border-b border-[#E0E0E0]
+             text-[12px] text-[#212121]"
+>
+  <div className="col-span-8 pl-4">공모전 목록</div>
+  <div className="col-span-2 text-center">상태</div>
+  <div className="col-span-2 text-center ">수상작</div>
+</div>
+
+{/* 목록 행: 헤더와 동일하게 gap-0 + px-4, 첫 행만 -1px 겹치기 */}
+{pageItems.map((p) => (
+  <div
+    key={p.projectId}
+    className="grid grid-cols-12 items-stretch gap-0
+               border-b border-[#F1F1F1] first:-mt-px"
+  >
+    {/* 좌측: 공모전 카드 클릭 → 상세로 이동 */}
+    <div className="col-span-8 py-3">
+      <Link
+        to={`/project-detail/${p.projectId}`}
+        className="block cursor-pointer hover:bg-[#FAFAFA] rounded-[6px] transition-colors"
+        aria-label={`${p.title || "공모전"} 상세보기`}
+      >
+        <MyProjectRow
+          project={p}
+          getCategoryLabel={getCategoryLabel}
+          getBusinessTypeLabel={getBusinessTypeLabel}
+        />
+      </Link>
+    </div>
+
+    {/* 가운데: 상태 */}
+    <div className="col-span-2 border-l border-[#E0E0E0]
+                    flex items-center justify-center py-3
+                    text-center text-[14px] text-[#222] font-medium">
+      {STATUS_LABEL[p.status] || p.status}
+    </div>
+
+    {/* 오른쪽: 수상작 */}
+    <div className="col-span-2 border-l border-[#E0E0E0]
+                    flex items-center justify-center py-3">
+      {renderAwardCell(p)}
+    </div>
+  </div>
+))}
+
+          <div className="flex justify-center my-6">
+            <Pagination
+              totalItems={projects.length}
+              page={page}
+              onPageChange={setPage}
+              pageSize={PAGE_SIZE}
+              blockSize={5}
+            />
+          </div>
+        </div>
+      </div>
+
+      <Footer />
+    </div>
+  );
+};
+
+export default MerchantMyProject;

--- a/src/pages/ParticipantMy.jsx
+++ b/src/pages/ParticipantMy.jsx
@@ -1,9 +1,0 @@
-import React from 'react'
-
-const ParticipantMy = () => {
-  return (
-    <div>ParticipantMy</div>
-  )
-}
-
-export default ParticipantMy

--- a/src/pages/ParticipantMyProject.jsx
+++ b/src/pages/ParticipantMyProject.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const ParticipantMyProject = () => {
+  return (
+    <div>ParticipantMyProject</div>
+  )
+}
+
+export default ParticipantMyProject


### PR DESCRIPTION
## 작업 개요
- 소상공인 계정으로 로그인합니다
```
아이디 - aa@a.a
비밀번호 - aaaaaaa1!
```
위 계정으로 로그인 테스트해주세요!
<img width="149" height="111" alt="image" src="https://github.com/user-attachments/assets/f1e6a481-eff2-4c42-bcfa-5900db7fc182" />
내 공모전에 들어갑니다
<img width="2325" height="1093" alt="image" src="https://github.com/user-attachments/assets/55d82857-62b1-42c0-b97b-db867e93b3c4" />
현재 위 계정으로 2개의 공모전을 등록하였고, 더 생기는 걸 확인하고 싶다면, 위 계정으로 공모전 등록하기 버튼 클릭 후 다시 내 공모전을 들어갔을때 목록이 생긴지 확인할 수 있습니다.
<img width="2559" height="1437" alt="image" src="https://github.com/user-attachments/assets/89215e06-5557-4365-8cd2-279fd657362f" />
소상공인이 목록을 클릭했을때 해당 목록의 상세페이지로 이동합니다.

- 투표가 API 와 아직 연동되지않아, 투표쪽과 연동X
## 변경 사항

- (구현한 주요 변경사항을 작성하세요)

## 관련 이슈

- (관련 이슈 번호나 링크를 작성하세요)
