### PR TITLE
Feature/submission-list-api : 공모전 참여작 조회 및 작품 상세 조회 기능 구현

### DIFF
--- a/src/apis/getSubmissionsApi.js
+++ b/src/apis/getSubmissionsApi.js
@@ -1,0 +1,17 @@
+// apis/getSubmissionsApi.js
+import authApi from "./authApi";
+
+// 특정 공모전의 작품 목록 조회 API
+export const fetchSubmissions = async (projectId) => {
+  try {
+    const token = sessionStorage.getItem("accessToken");
+    if (!token) throw new Error("로그인이 필요합니다.");
+
+    const api = authApi(token);
+    const res = await api.get(`/projects/${projectId}/submissions`);
+    return res.data;
+  } catch (error) {
+    console.error("작품 목록 조회 실패:", error);
+    throw error;
+  }
+};

--- a/src/apis/submissionApi.js
+++ b/src/apis/submissionApi.js
@@ -1,0 +1,15 @@
+import authApi from "./authApi";
+
+// 작품 상세 조회 API
+export const fetchSubmissionDetail = async (submissionId) => {
+  try {
+    const token = sessionStorage.getItem("accessToken");
+    if (!token) throw new Error("로그인이 필요합니다.");
+    const api = authApi(token);
+    const res = await api.get(`submissions/${submissionId}`);
+    return res.data;
+  } catch (error) {
+    console.error("작품 상세 조회 실패:", error);
+    throw error;
+  }
+};

--- a/src/components/SubmissionDetailModal.jsx
+++ b/src/components/SubmissionDetailModal.jsx
@@ -1,44 +1,38 @@
 import React, { useEffect, useState } from "react";
 import { IoIosClose } from "react-icons/io";
-import { fetchUserInfo } from "../apis/userApi";
 import { IoPersonCircle } from "react-icons/io5";
+import { fetchSubmissionDetail } from "../apis/submissionApi";
 
-const SubmissionPreviewModal = ({
-  isOpen,
-  onClose,
-  projectTitle,
-  uploadedImage,
-  description,
-  link,
-}) => {
-  const [nickname, setNickname] = useState("");
+const SubmissionDetailModal = ({ isOpen, onClose, submissionId }) => {
+  const [submission, setSubmission] = useState(null);
 
   useEffect(() => {
-    const getUserInfo = async () => {
+    if (!isOpen || !submissionId) return;
+
+    const getSubmission = async () => {
       try {
-        const user = await fetchUserInfo();
-        setNickname(user.nickname);
+        const data = await fetchSubmissionDetail(submissionId);
+        setSubmission(data);
       } catch (error) {
-        console.error(error);
+        console.error("작품 상세 조회 실패:", error);
       }
     };
-    getUserInfo();
-  }, []);
+
+    getSubmission();
+  }, [isOpen, submissionId]);
 
   useEffect(() => {
     if (!isOpen) return;
-
     const onKey = (e) => e.key === "Escape" && onClose();
     document.addEventListener("keydown", onKey);
     document.body.classList.add("modal-open");
-
     return () => {
       document.removeEventListener("keydown", onKey);
       document.body.classList.remove("modal-open");
     };
   }, [isOpen, onClose]);
 
-  if (!isOpen) return null;
+  if (!isOpen || !submission) return null;
 
   return (
     <div
@@ -58,41 +52,43 @@ const SubmissionPreviewModal = ({
           {/* 모달 박스 */}
           <div className="bg-white rounded-[12px] max-w-[1032px] max-h-[1550px] overflow-y-auto px-[64px] py-[63px]">
             <div>
-              {/* 사용자 닉네임 */}
+              {/* 작성자 */}
               <div className="flex space-x-[8px] mb-[11px]">
                 <IoPersonCircle className="text-[#A3A3A3] w-[19.5px] h-[19.5px]" />
                 <p className="text-[#A3A3A3] text-[14px] font-medium">
-                  {nickname}
+                  {submission.writer}
                 </p>
               </div>
 
               {/* 제목 */}
               <h2 className="text-[28px] font-semibold text-black">
-                {projectTitle}
+                {submission.title}
               </h2>
               <hr className="w-[904px] border-[1px] border-[#E1E1E1] mt-[40px] mb-[60px]" />
 
               {/* 이미지 */}
               <img
-                src={uploadedImage}
+                src={submission.imageUrl}
                 alt="작품 이미지"
                 className="max-w-[904px] max-h-[904px] rounded-[6px] mb-[16px]"
               />
 
               {/* 설명 */}
               <p className="text-[#212121] text-[16px] whitespace-pre-line mb-[24px]">
-                {description}
+                {submission.description}
               </p>
 
               {/* 링크 */}
-              <a
-                href={link}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-[#212121] underline"
-              >
-                {link}
-              </a>
+              {submission.relatedUrl && (
+                <a
+                  href={submission.relatedUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[#212121] underline"
+                >
+                  {submission.relatedUrl}
+                </a>
+              )}
             </div>
           </div>
         </div>
@@ -101,4 +97,4 @@ const SubmissionPreviewModal = ({
   );
 };
 
-export default SubmissionPreviewModal;
+export default SubmissionDetailModal;

--- a/src/components/SubmissionThumbnail.jsx
+++ b/src/components/SubmissionThumbnail.jsx
@@ -1,24 +1,24 @@
 import React from "react";
 
-const SubmissionThumbnail = ({ submission, onClick }) => {
+const SubmissionThumbnail = ({ submission, onClick, isBlur }) => {
   return (
     <div
-      className="w-[240px] rounded-lg cursor-pointer flex flex-col overflow-hidden shadow-md"
+      className="w-[240px] h-[306px] rounded-lg cursor-pointer flex flex-col overflow-hidden border border-[#E1E1E1]"
       onClick={() => onClick(submission)}
     >
-      <div className="bg-[#EBEBEB] h-[200px] w-full flex items-center justify-center">
+      <div className="bg-[#EBEBEB] w-[240px] h-[240px] flex items-center justify-center">
         {submission.imageUrl ? (
           <img
             src={submission.imageUrl}
             alt="참여 이미지"
-            className="w-full h-full object-cover"
+            className={`w-full h-full object-cover ${isBlur ? "blur-xs" : ""}`}
           />
         ) : (
           <div className="text-[#A3A3A3] text-sm">이미지 없음</div>
         )}
       </div>
-      <div className="p-4 bg-white">
-        <h3 className="text-[#212121] text-[14px] font-medium truncate">
+      <div className="p-5 bg-white font-pretendard">
+        <h3 className="text-[#212121] text-[16px] font-semibold truncate">
           {submission.title || "제목 없음"}
         </h3>
       </div>

--- a/src/components/SubmissionThumbnail.jsx
+++ b/src/components/SubmissionThumbnail.jsx
@@ -18,7 +18,7 @@ const SubmissionThumbnail = ({ submission, onClick, isBlur }) => {
         )}
       </div>
       <div className="p-5 bg-white font-pretendard">
-        <h3 className="text-[#212121] text-[16px] font-semibold truncate">
+        <h3 className="text-[#212121] text-[16px] font-semibold truncate hover:text-[#626262]">
           {submission.title || "제목 없음"}
         </h3>
       </div>

--- a/src/pages/ProjectDetail.jsx
+++ b/src/pages/ProjectDetail.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
 import MerchantHeader from "../header/MerchantHeader";
 import api from "../apis/api";
 import { fetchSubmissions } from "../apis/getSubmissionsApi";
@@ -37,7 +37,6 @@ const formatCurrency = (amount) => {
 };
 
 const ProjectDetail = ({ role }) => {
-  const [activeTab, setActiveTab] = useState("CONTENT");
   const [projectData, setProjectData] = useState(null);
   const [submissions, setSubmissions] = useState([]);
   const [selectedSubmission, setSelectedSubmission] = useState(null);
@@ -49,6 +48,9 @@ const ProjectDetail = ({ role }) => {
 
   const { projectId } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
+  const initialTab = location.state?.initialTab || "CONTENT";
+  const [activeTab, setActiveTab] = useState(initialTab);
 
   useEffect(() => {
     const fetchProjectDetails = async () => {

--- a/src/pages/ProjectDetail.jsx
+++ b/src/pages/ProjectDetail.jsx
@@ -119,7 +119,13 @@ const ProjectDetail = ({ role }) => {
   };
 
   const handleSubmissionClick = (submission) => {
-    setSelectedSubmission(submission);
+    const canOpenDetail =
+      (isMerchant && isMyProject) || // 소상공인 & 내 공모전일 때
+      (isParticipant && submission.userId === userInfo?.user_id); // 참가자 & 내 작품일 때
+
+    if (canOpenDetail) {
+      setSelectedSubmission(submission);
+    }
   };
 
   const handleCloseSubmissionModal = () => {
@@ -509,7 +515,12 @@ const ProjectDetail = ({ role }) => {
 
       {selectedSubmission && (
         <SubmissionDetailModal
-          isOpen={!!selectedSubmission}
+          isOpen={
+            !!selectedSubmission &&
+            ((isMerchant && isMyProject) || // 소상공인 & 내 공모전
+              (isParticipant &&
+                selectedSubmission.userId === userInfo?.user_id)) // 참가자 & 내 작품
+          }
           submissionId={selectedSubmission.submissionId}
           onClose={handleCloseSubmissionModal}
         />

--- a/src/pages/ProjectDetail.jsx
+++ b/src/pages/ProjectDetail.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import MerchantHeader from "../header/MerchantHeader";
 import api from "../apis/api";
+import { fetchSubmissions } from "../apis/getSubmissionsApi";
 
 // 아이콘 및 이미지
 import calendarIcon from "../assets/calendarIcon.png";
@@ -34,33 +35,6 @@ const formatCurrency = (amount) => {
   return `${numericAmount.toLocaleString()}원`;
 };
 
-const DUMMY_SUBMISSIONS = [
-  {
-    id: 1,
-    title: "참여작 제목 1",
-    writerNickname: "참가자1",
-    imageUrl: "https://via.placeholder.com/600/D3D3D3/000000?text=Submission+1",
-    description:
-      "참여작 내용입니다. 이 작업은 프로젝트의 요구 사항을 충족시키기 위해 제작되었습니다.",
-  },
-  {
-    id: 2,
-    title: "참여작 제목 2",
-    writerNickname: "참가자2",
-    imageUrl: "https://via.placeholder.com/600/D3D3D3/000000?text=Submission+2",
-    description:
-      "두 번째 참여작입니다. 다양한 디자인 요소를 활용하여 제작된 작품입니다.",
-  },
-  {
-    id: 3,
-    title: "참여작 제목 3",
-    writerNickname: "참가자3",
-    imageUrl: "https://via.placeholder.com/600/D3D3D3/000000?text=Submission+3",
-    description:
-      "세 번째 참여작입니다. 창의적인 아이디어를 담아 만들어졌습니다.",
-  },
-];
-
 const ProjectDetail = ({ role }) => {
   const [activeTab, setActiveTab] = useState("CONTENT");
   const [projectData, setProjectData] = useState(null);
@@ -80,6 +54,9 @@ const ProjectDetail = ({ role }) => {
         setLoading(true);
         const projectResponse = await api.get(`/projects/${projectId}`);
         setProjectData(projectResponse.data);
+        const submissionsData = await fetchSubmissions(projectId);
+        setSubmissions(submissionsData);
+
         setError(null);
       } catch (err) {
         console.error("Failed to fetch project details:", err);
@@ -94,8 +71,6 @@ const ProjectDetail = ({ role }) => {
       }
     };
 
-    // API 호출 대신 더미 데이터 사용
-    setSubmissions(DUMMY_SUBMISSIONS);
     fetchProjectDetails();
   }, [projectId]);
 

--- a/src/pages/ProjectDetail.jsx
+++ b/src/pages/ProjectDetail.jsx
@@ -22,6 +22,7 @@ import ContentSubmissionsTabs from "../components/ContentSubmissionsTabs";
 import Footer from "../components/Footer";
 import DeleteModal from "../components/DeleteModal";
 import SubmissionThumbnail from "../components/SubmissionThumbnail";
+import SubmissionDetailModal from "../components/SubmissionDetailModal";
 
 const formatCurrency = (amount) => {
   if (amount === null || amount === undefined) {
@@ -508,7 +509,8 @@ const ProjectDetail = ({ role }) => {
 
       {selectedSubmission && (
         <SubmissionDetailModal
-          submission={selectedSubmission}
+          isOpen={!!selectedSubmission}
+          submissionId={selectedSubmission.submissionId}
           onClose={handleCloseSubmissionModal}
         />
       )}

--- a/src/pages/ProjectDetail.jsx
+++ b/src/pages/ProjectDetail.jsx
@@ -53,7 +53,14 @@ const ProjectDetail = ({ role }) => {
   const initialTab = location.state?.initialTab || "CONTENT";
   const [activeTab, setActiveTab] = useState(initialTab);
 
+  // 참가자가 제출한 작품이 있는지 여부
+  const hasMySubmission = submissions.some(
+    (sub) => sub.userId === userInfo?.user_id
+  );
+
   useEffect(() => {
+    if (!userInfo) return;
+
     const fetchProjectDetails = async () => {
       try {
         setLoading(true);
@@ -77,7 +84,7 @@ const ProjectDetail = ({ role }) => {
     };
 
     fetchProjectDetails();
-  }, [projectId]);
+  }, [projectId, location.state?.refresh, userInfo]);
 
   // 사용자 정보 조회
   useEffect(() => {
@@ -320,10 +327,17 @@ const ProjectDetail = ({ role }) => {
           {/* 참가자로 로그인한 경우 참가하기 버튼 보이게 */}
           {role === "participant" && (
             <button
-              onClick={() => navigate(`/projects/${projectId}/submission`)}
-              className="w-[95px] h-[45px] px-[20px] py-[12px] text-[16px] font-medium bg-[#2FD8F6] text-white rounded-[8px] leading-[130%] tracking-[-0.02em] hover:bg-[#2AC2DD] cursor-pointer"
+              onClick={() =>
+                !hasMySubmission &&
+                navigate(`/projects/${projectId}/submission`)
+              }
+              className={`w-[95px] h-[45px] px-[20px] py-[12px] text-[16px] font-medium rounded-[8px] leading-[130%] tracking-[-0.02em]  ${
+                hasMySubmission
+                  ? "bg-[#E1E1E1] text-white"
+                  : "bg-[#2FD8F6] text-white hover:bg-[#2AC2DD] cursor-pointer"
+              }`}
             >
-              참가하기
+              {hasMySubmission ? "참가완료" : "참가하기"}
             </button>
           )}
 

--- a/src/pages/ProjectSubmissionPage.jsx
+++ b/src/pages/ProjectSubmissionPage.jsx
@@ -16,9 +16,10 @@ import checklistIcon3 from "../assets/checklistIcon3.png";
 import checklistIcon4 from "../assets/checklistIcon4.png";
 import checklistIcon5 from "../assets/checklistIcon5.png";
 import checklistIcon6 from "../assets/checklistIcon6.png";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 const ProjectSubmissionPage = () => {
+  const navigate = useNavigate();
   const { projectId } = useParams();
   const [allChecked, setAllChecked] = useState(false);
   const [checkList, setCheckList] = useState({
@@ -86,6 +87,9 @@ const ProjectSubmissionPage = () => {
 
       alert("제출이 완료되었습니다!");
       setIsConfirmSubmissionOpen(false);
+      navigate(`/project-detail/${projectId}`, {
+        state: { initialTab: "SUBMISSIONS" },
+      });
     } catch (error) {
       console.error("제출 실패:", error);
       alert("제출에 실패했습니다. 다시 시도해주세요.");

--- a/src/pages/ProjectSubmissionPage.jsx
+++ b/src/pages/ProjectSubmissionPage.jsx
@@ -84,11 +84,10 @@ const ProjectSubmissionPage = () => {
         link,
         image: uploadedImage,
       });
-
       alert("제출이 완료되었습니다!");
       setIsConfirmSubmissionOpen(false);
-      navigate(`/project-detail/${projectId}`, {
-        state: { initialTab: "SUBMISSIONS" },
+      navigate(`/project-detail-participant/${projectId}`, {
+        state: { initialTab: "SUBMISSIONS", refresh: true },
       });
     } catch (error) {
       console.error("제출 실패:", error);


### PR DESCRIPTION
## 작업 개요

- 공모전 상세 페이지에서 참여작 목록 조회 기능 구현 - (기존 목업 데이터 삭제)
- 역할(소상공인/참가자)에 따른 참여작 표시 방식 및 상세 모달 조건 추가
- 참가자 작품 제출 성공 시 상세페이지 참여작 탭으로 이동하도록 구현
<img width="1857" height="921" alt="image" src="https://github.com/user-attachments/assets/51307325-da98-4e01-86b6-84982e07a340" />
<img width="1412" height="890" alt="image" src="https://github.com/user-attachments/assets/25217c60-2a20-4acd-8628-34d694a86893" />

## 테스트 목록
#### 1. 소상공인 로그인 후
- 공모전 등록 임의로 새로 하고
- 자신이 등록한 공모전 클릭 -> 참여작 탭 - **모든 참여작들 보임(블러x) + 작품 클릭 시 상세 내용 보임**
<img width="1658" height="746" alt="image" src="https://github.com/user-attachments/assets/3815c786-1aad-4c2e-9ccc-c8ac674b0bfc" />

- 남의 공모전 클릭 -> 참여작 탭 - **모든 참여작들이 블러 처리된 형태로 보임 + 작품 클릭 시 상세 내용 뜨지 않아야함**
<img width="1862" height="921" alt="image" src="https://github.com/user-attachments/assets/3a751605-5324-479d-85aa-42c98ed05cb7" />

#### 2. 참가자 로그인 후
- 임의의 공모전 클릭 후 작품 제출 -> 제출 성공 시 참가한 공모전의 상세페이지 - 참여작 탭으로 이동
- **방금 제출한 작품이 블러 효과 없이 제일 앞에 떠야하며, 자신의 작품 클릭 시 상세 내용 떠야함**
- **자신이 제출한 작품 이외의 작품들은 모두 블러 처리로 떠야하며, 작품 클릭 시 상세 내용 뜨지 않아야함**
<img width="1876" height="923" alt="image" src="https://github.com/user-attachments/assets/13afbd35-d269-40f8-be7a-1f9532a6fbe2" />

## 변경 사항

- 작품 목록 조회 API 연동
- 작품 상세 조회 API 연동

## 관련 이슈

- 이번 작업하면서 삭제 기능에 오류 발견 -> 자신이 등록한 공모전이 아니여도 삭제되는 상황
- 이후 삭제 관련 작업 하겠습니다^.^
