### PR TITLE
fix : ProjectDetail 페이지에서 역할별 헤더 올바르게 표시되도록 수정

### DIFF
--- a/src/pages/ProjectDetail.jsx
+++ b/src/pages/ProjectDetail.jsx
@@ -23,6 +23,7 @@ import Footer from "../components/Footer";
 import DeleteModal from "../components/DeleteModal";
 import SubmissionThumbnail from "../components/SubmissionThumbnail";
 import SubmissionDetailModal from "../components/SubmissionDetailModal";
+import ParticipantHeader from "../header/ParticipantHeader";
 
 const formatCurrency = (amount) => {
   if (amount === null || amount === undefined) {
@@ -228,7 +229,7 @@ const ProjectDetail = ({ role }) => {
 
   return (
     <div className="flex flex-col min-h-screen font-pretendard">
-      <MerchantHeader />
+      {isMerchant ? <MerchantHeader /> : <ParticipantHeader />}
       <div className="flex-grow bg-[#FFFFFF] py-8 px-40">
         <div className="p-15">
           <div className="flex items-center justify-between text-gray-500 text-sm mb-4">
@@ -539,6 +540,7 @@ const ProjectDetail = ({ role }) => {
           }
           submissionId={selectedSubmission.submissionId}
           onClose={handleCloseSubmissionModal}
+          role={role}
         />
       )}
     </div>


### PR DESCRIPTION
## 변경 사항

- 문제 : 공모전 상세페이지에서 소상공인이든 참가자든 소상공인 헤더가 띄워졌음
- ProjectDetail에서 Merchant/Participant 역할에 따라 헤더가 다르게 표시되도록 수정
```jsx
{isMerchant ? <MerchantHeader /> : <ParticipantHeader />}
```


