### PR TITLE
Feature/guest-main-page : 게스트(로그인 하지 않은 사용자) 메인 화면 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import ProjectSubmissionPage from "./pages/ProjectSubmissionPage";
 
 import MerchantMyProject from "./pages/MerchantMyProject.jsx";
 import ParticipantMyProject from "./pages/ParticipantMyProject.jsx";
+import GuestMainPage from "./pages/GuestMainPage.jsx";
 
 export default function App() {
   return (
@@ -34,25 +35,23 @@ export default function App() {
             />
           </Route>
           <Route path="/merchant-main-page" element={<MerchantMainPage />} />
-          <Route
-            path="/search"
-            element={<SearchPage showRegisterButton={true} />}
-          />
+          <Route path="/search" element={<SearchPage />} />
           <Route
             path="/participant-main-page"
             element={<ParticipantMainPage />}
           />
-          <Route
-            path="/participant-search"
-            element={<SearchPage showRegisterButton={false} />}
-          />
+          <Route path="/participant-search" element={<SearchPage />} />
+          <Route path="guest-main-page" element={<GuestMainPage />} />
+          <Route path="/guest-search" element={<SearchPage />} />
           <Route
             path="/projects/:projectId/submission"
             element={<ProjectSubmissionPage />}
           />
-           <Route path="merchant-myproject" element={<MerchantMyProject/>}/>
-            <Route path="participant-myproject" element={<ParticipantMyProject/>}/>
-      
+          <Route path="merchant-myproject" element={<MerchantMyProject />} />
+          <Route
+            path="participant-myproject"
+            element={<ParticipantMyProject />}
+          />
         </Routes>
       </BrowserRouter>
     </AuthProvider>

--- a/src/components/LoginRequiredModal.jsx
+++ b/src/components/LoginRequiredModal.jsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { IoIosClose } from "react-icons/io";
+
+const LoginRequiredModal = ({ onClose }) => {
+  return (
+    <div className="fixed inset-0 z-10000 bg-black/50 overflow-y-auto font-pretendard flex items-center justify-center">
+      <div className="relative bg-white rounded-[12px] shadow-lg pt-[32px] pb-[23px] w-[420px] h-[240px] text-center">
+        <button
+          onClick={onClose}
+          className="absolute top-3 right-3 text-[#A3A3A3] cursor-pointer"
+        >
+          <IoIosClose className="w-[40px] h-[40px]" />
+        </button>
+        <h2 className="text-[20px] font-semibold mb-[8px]">
+          로그인이 필요해요 😊
+        </h2>
+        <p className="text-[14px] text-[#828282] mb-[36px]">
+          공모전은 자유롭게 구경하실 수 있지만, <br />더 많은 기능을 이용하려면
+          로그인이 필요합니다.
+        </p>
+        <div className="flex flex-col items-center gap-3">
+          <Link
+            to="/signin"
+            className="w-[180px] h-[45px] flex items-center justify-center
+               bg-[#2FD8F6] text-white text-[16px] font-medium rounded-[8px]
+               hover:bg-[#2AC2DD] cursor-pointer"
+          >
+            로그인하러 가기
+          </Link>
+          <Link
+            to="/signup"
+            className="text-[12px] text-[#A3A3A3] hover:underline cursor-pointer"
+          >
+            회원가입
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LoginRequiredModal;

--- a/src/header/GuestHeader.jsx
+++ b/src/header/GuestHeader.jsx
@@ -1,0 +1,80 @@
+import React, { useState } from "react";
+import logo from "../assets/logo.png";
+import { BiSearch } from "react-icons/bi";
+import { IoPersonCircle } from "react-icons/io5";
+import { Link, useNavigate } from "react-router-dom";
+import { IoIosClose } from "react-icons/io";
+
+const GuestHeader = ({ defaultValue = "" }) => {
+  const [value, setValue] = useState(defaultValue);
+  const navigate = useNavigate();
+
+  const submit = (e) => {
+    e.preventDefault();
+    const q = value.trim();
+    navigate(q ? `/search?q=${encodeURIComponent(q)}` : "/search");
+  };
+
+  return (
+    <div className="w-full h-[60px] flex items-center px-[120px] border-b border-gray-200 font-pretendard">
+      {/* 로고 */}
+      <div className="flex-1 flex justify-start">
+        <Link to="/guest-main-page">
+          <img
+            src={logo}
+            alt="로고"
+            className="w-[89.65px] h-[20px] cursor-pointer"
+          />
+        </Link>
+      </div>
+
+      {/* 검색창 */}
+      <div className="flex-1 flex justify-center">
+        <form
+          onSubmit={submit}
+          className="flex items-center w-[480px] h-[36px] bg-[#F3F3F3] border-[1px] border-transparent
+      focus-within:bg-[#FBFBFB] focus-within:border-[#2FD8F6] rounded-[18px] px-3"
+        >
+          <BiSearch className="text-[#A3A3A3] w-[14px] h-[14px] ml-1" />
+          <input
+            type="text"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="어떤 공모전을 찾고있나요?"
+            className="w-full ml-1.5 bg-[#F3F3F3] text-[12px] text-[#212121] placeholder:text-[12px] placeholder:text-[#A3A3A3] placeholder:font-medium focus:bg-[#FBFBFB] focus:outline-none"
+          />
+          {/* 입력값이 있을 때만 X 아이콘 표시 */}
+          {value && (
+            <IoIosClose
+              className="text-[#212121] w-[20px] h-[20px] cursor-pointer"
+              onClick={() => setValue("")}
+            />
+          )}
+          {/* 보이지 않는 submit 버튼(엔터 제출용) */}
+          <button type="submit" className="hidden">
+            검색
+          </button>
+        </form>
+      </div>
+
+      {/* 버튼들 */}
+      <div className="flex-1 flex justify-end gap-8">
+        <button
+          onClick={() => navigate("/merchant-myproject")}
+          className="text-[12px] text-[#4C4C4C] font-[12px] cursor-pointer"
+        >
+          내 공모전
+        </button>
+        <Link
+          to="/signin"
+          className="w-[109px] h-[32px] px-[16px] py-[8px] text-[#4C4C4C] font-medium border-[1px] border-[#4C4C4C] rounded-[6px] text-[12px] cursor-pointer hover:bg-[#2FD8F6] leading-[130%] tracking-[-0.02em]"
+        >
+          로그인/회원가입
+        </Link>
+        <IoPersonCircle className="text-[#B9B9B9] w-[32px] h-[32px] cursor-pointer" />
+      </div>
+    </div>
+  );
+};
+
+export default GuestHeader;

--- a/src/header/GuestHeader.jsx
+++ b/src/header/GuestHeader.jsx
@@ -4,15 +4,17 @@ import { BiSearch } from "react-icons/bi";
 import { IoPersonCircle } from "react-icons/io5";
 import { Link, useNavigate } from "react-router-dom";
 import { IoIosClose } from "react-icons/io";
+import LoginRequiredModal from "../components/LoginRequiredModal";
 
 const GuestHeader = ({ defaultValue = "" }) => {
   const [value, setValue] = useState(defaultValue);
+  const [showLoginModal, setShowLoginModal] = useState(false);
   const navigate = useNavigate();
 
   const submit = (e) => {
     e.preventDefault();
     const q = value.trim();
-    navigate(q ? `/search?q=${encodeURIComponent(q)}` : "/search");
+    navigate(q ? `/guest-search?q=${encodeURIComponent(q)}` : "/guest-search");
   };
 
   return (
@@ -60,7 +62,7 @@ const GuestHeader = ({ defaultValue = "" }) => {
       {/* 버튼들 */}
       <div className="flex-1 flex justify-end gap-8">
         <button
-          onClick={() => navigate("/merchant-myproject")}
+          onClick={() => setShowLoginModal(true)}
           className="text-[12px] text-[#4C4C4C] font-[12px] cursor-pointer"
         >
           내 공모전
@@ -73,6 +75,9 @@ const GuestHeader = ({ defaultValue = "" }) => {
         </Link>
         <IoPersonCircle className="text-[#B9B9B9] w-[32px] h-[32px] cursor-pointer" />
       </div>
+      {showLoginModal && (
+        <LoginRequiredModal onClose={() => setShowLoginModal(false)} />
+      )}
     </div>
   );
 };

--- a/src/main/ProjectList.jsx
+++ b/src/main/ProjectList.jsx
@@ -38,6 +38,7 @@ const ProjectList = ({
   selectedBusinesses = [],
   hideHeader = false,
   role,
+  onRequireLogin,
 }) => {
   const [page, setPage] = useState(1); // 현재 보고있는 페이지 번호 상태
   const [projects, setProjects] = useState([]);
@@ -145,6 +146,7 @@ const ProjectList = ({
                 categories={categories}
                 businessTypes={businessTypes}
                 role={role}
+                onRequireLogin={onRequireLogin}
               />
             );
           })}

--- a/src/main/projectCard/ProjectCardClosed.jsx
+++ b/src/main/projectCard/ProjectCardClosed.jsx
@@ -10,19 +10,22 @@ const ProjectCardClosed = ({
   project,
   categories = [],
   businessTypes = [],
+  role,
+  onRequireLogin,
 }) => {
-  // categories 배열에서 현재 프로젝트 category(code)와 매칭되는 객체 찾기
   const categoryObj = categories.find((c) => c.code === project.category);
   const businessTypeObj = businessTypes.find(
     (b) => b.code === project.businessType
   );
 
-  return (
+  // 카드 내용 공통
+  const cardContent = (
     <div className="flex space-x-[24px] w-[856px] h-[252px] border border-[#E1E1E1] rounded-[12px] font-pretendard hover:opacity-60 hover:border-[#A3A3A3]">
-      {/* 수상작 대표 이미지 -> 작품 선정 기능이 완료되면 선정된 작품 API에서 이미지 받아올 것 */}
+      {/* 수상작 대표 이미지 */}
       <img
         src={projectImgExample}
         className="w-[228px] h-[228px] mt-[12px] ml-[12px] rounded-[8px]"
+        alt="대표 이미지"
       />
       <div>
         {/* 카테고리/업종 */}
@@ -107,6 +110,18 @@ const ProjectCardClosed = ({
       </div>
     </div>
   );
+
+  // role 분기
+  if (role === "guest") {
+    return (
+      <div onClick={() => onRequireLogin?.()} className="cursor-pointer">
+        {cardContent}
+      </div>
+    );
+  }
+
+  // 추후 상세 페이지 연결 예정
+  return cardContent;
 };
 
 export default ProjectCardClosed;

--- a/src/main/projectCard/ProjectCardInProgress.jsx
+++ b/src/main/projectCard/ProjectCardInProgress.jsx
@@ -12,6 +12,7 @@ const ProjectCardInProgress = ({
   categories = [],
   businessTypes = [],
   role,
+  onRequireLogin,
 }) => {
   // categories 배열에서 현재 프로젝트 category(code)와 매칭되는 객체 찾기
   const categoryObj = categories.find((c) => c.code === project.category);
@@ -106,16 +107,30 @@ const ProjectCardInProgress = ({
     </div>
   );
 
-  // role이 merchant -> 소상공인 공모전 상세 페이지 이동, participant -> 참가자 공모전 상세 페이지 이동
-  return role === "merchant" ? (
-    <Link to={`/project-detail/${project.projectId}`}>{cardContent}</Link>
-  ) : role === "participant" ? (
-    <Link to={`/project-detail-participant/${project.projectId}`}>
-      {cardContent}
-    </Link>
-  ) : (
-    cardContent
-  );
+  // role이 merchant -> 소상공인 공모전 상세 페이지 이동, participant -> 참가자 공모전 상세 페이지 이동, guest -> 로그인 모달
+  if (role === "merchant") {
+    return (
+      <Link to={`/project-detail/${project.projectId}`}>{cardContent}</Link>
+    );
+  }
+
+  if (role === "participant") {
+    return (
+      <Link to={`/project-detail-participant/${project.projectId}`}>
+        {cardContent}
+      </Link>
+    );
+  }
+
+  if (role === "guest") {
+    return (
+      <div onClick={() => onRequireLogin?.()} className="cursor-pointer">
+        {cardContent}
+      </div>
+    );
+  }
+
+  return cardContent;
 };
 
 export default ProjectCardInProgress;

--- a/src/main/projectCard/ProjectCardVoting.jsx
+++ b/src/main/projectCard/ProjectCardVoting.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import prizeIcon from "../../assets/prizeIcon.png";
 import participantIcon from "../../assets/participantIcon.png";
 import calendarIcon from "../../assets/calendarIcon.png";
@@ -9,14 +10,15 @@ const ProjectCardVoting = ({
   project,
   categories = [],
   businessTypes = [],
+  role,
+  onRequireLogin,
 }) => {
-  // categories 배열에서 현재 프로젝트 category(code)와 매칭되는 객체 찾기
   const categoryObj = categories.find((c) => c.code === project.category);
   const businessTypeObj = businessTypes.find(
     (b) => b.code === project.businessType
   );
 
-  return (
+  const cardContent = (
     <div className="w-[856px] h-[252px] border border-[#E1E1E1] rounded-[12px] pl-[28px] font-pretendard hover:opacity-60 hover:border-[#A3A3A3]">
       {/* 카테고리/업종 */}
       <div className="flex gap-[4px] text-[12px] text-[#A3A3A3] font-medium mt-[20px]">
@@ -32,8 +34,8 @@ const ProjectCardVoting = ({
         {(() => {
           const today = new Date();
           const end = new Date(project.deadline);
-          end.setDate(end.getDate() + 7); // 투표 종료일 = 공모전 마감일 + 7일
-          const startOfToday = new Date( // 자정으로 세팅 (날짜 기준으로 계산되게)
+          end.setDate(end.getDate() + 7);
+          const startOfToday = new Date(
             today.getFullYear(),
             today.getMonth(),
             today.getDate()
@@ -126,6 +128,18 @@ const ProjectCardVoting = ({
       </div>
     </div>
   );
+
+  // role 분기
+  if (role === "guest") {
+    return (
+      <div onClick={() => onRequireLogin?.()} className="cursor-pointer">
+        {cardContent}
+      </div>
+    );
+  }
+
+  // 추후 participant/merchant 전용 투표 상세 페이지 연결 해야함!!
+  return cardContent;
 };
 
 export default ProjectCardVoting;

--- a/src/pages/GuestMainPage.jsx
+++ b/src/pages/GuestMainPage.jsx
@@ -1,0 +1,71 @@
+import React, { useState } from "react";
+import ProjectStatusTabs from "../main/ProjectStatusTabs";
+import CategoryFilter from "../main/CategoryFilter";
+import ProjectList from "../main/ProjectList";
+import { BiSolidPencil } from "react-icons/bi";
+import Footer from "../components/Footer";
+import MerchantBanner from "../main/MerchantBanner";
+import GuestHeader from "../header/GuestHeader";
+import LoginRequiredModal from "../components/LoginRequiredModal";
+
+const GuestMainPage = () => {
+  const [activeTab, setActiveTab] = useState("CLOSED");
+  const [selectedCategories, setSelectedCategories] = useState([]);
+  const [selectedBusinesses, setSelectedBusinesses] = useState([]);
+  const [q, setQ] = useState("");
+  const [isSearched, setIsSearched] = useState(false);
+  const [categories, setCategories] = useState([]);
+  const [businessTypes, setBusinessTypes] = useState([]);
+  const [showLoginModal, setShowLoginModal] = useState(false);
+
+  return (
+    <div>
+      <GuestHeader />
+      <MerchantBanner />
+      <ProjectStatusTabs activeTab={activeTab} setActiveTab={setActiveTab} />
+      <div className="flex px-[240px] gap-[40px]">
+        <CategoryFilter
+          categories={categories}
+          setCategories={setCategories}
+          businessTypes={businessTypes}
+          setBusinessTypes={setBusinessTypes}
+          selectedCategories={selectedCategories}
+          setSelectedCategories={setSelectedCategories}
+          selectedBusinesses={selectedBusinesses}
+          setSelectedBusinesses={setSelectedBusinesses}
+        />
+        <ProjectList
+          q={q}
+          isSearched={isSearched}
+          activeTab={activeTab}
+          categories={categories}
+          businessTypes={businessTypes}
+          selectedCategories={selectedCategories}
+          selectedBusinesses={selectedBusinesses}
+          role="guest"
+          onRequireLogin={() => setShowLoginModal(true)}
+        />
+      </div>
+      <Footer />
+
+      {/* 공모전 등록하기 버튼 */}
+      <button
+        onClick={() => setShowLoginModal(true)}
+        className="fixed bottom-[50px] right-[110px] z-[9999]
+             flex items-center gap-[6px] pl-[16px] pr-[20px] py-[12px] w-[157px] h-[45px]
+             rounded-[8px] bg-[#2FD8F6] text-white hover:bg-[#2AC2DD] cursor-pointer"
+      >
+        <BiSolidPencil className="w-[16px] h-[16px]" />
+        <span className="text-[16px] font-medium font-pretendard leading-[130%] tracking-[-0.02em]">
+          공모전 등록하기
+        </span>
+      </button>
+
+      {showLoginModal && (
+        <LoginRequiredModal onClose={() => setShowLoginModal(false)} />
+      )}
+    </div>
+  );
+};
+
+export default GuestMainPage;

--- a/src/pages/Rending.jsx
+++ b/src/pages/Rending.jsx
@@ -1,30 +1,42 @@
-import React from 'react'
-import { Link } from 'react-router-dom'
-
+import React from "react";
+import { Link } from "react-router-dom";
 
 const Rending = () => {
   return (
     <>
-
-    <div className='flex flex-col items-center gap-5 mt-40 font-pretendard'>
-    <span className='font-bold text-4xl'>가게에 필요한 것,쉽게 요청하고 받아보세요.</span>
-    <span className='text-[#626262]'>브릿지는 경산의 소상공인과 지역 주민이 연결될 수 있도록 돕는 B2P 공모 플랫폼입니다.</span>
-    <div className='flex gap-3 mt-4'>
-
-        <Link className='border border-[#2FD8F6] bg-[#EAFBFE] hover:bg-[#E0F9FE] rounded-xl w-[140px] h-[45px] flex items-center justify-center text-[#2FD8F6]'
-       to="/signup" state={{ presetRole: "참가자" }}>
-        공모전 참여하기
-      </Link>
-       <Link className='border rounded-xl bg-[#2FD8F6] hover:bg-[#2AC2DD] w-[140px] h-[45px] text-[#FFFFFF] flex items-center justify-center'
-       to="/signup" state={{ presetRole: "소상공인" }}>
-       도움 요청하기
-       </Link>
-   
-    </div>
-    <Link className='text-[#A3A3A3] underline text-sm' to="/participant-main-page">지금 올라온 공모전 둘러보기</Link>
-    </div>
+      <div className="flex flex-col items-center gap-5 mt-40 font-pretendard">
+        <span className="font-bold text-4xl">
+          가게에 필요한 것,쉽게 요청하고 받아보세요.
+        </span>
+        <span className="text-[#626262]">
+          브릿지는 경산의 소상공인과 지역 주민이 연결될 수 있도록 돕는 B2P 공모
+          플랫폼입니다.
+        </span>
+        <div className="flex gap-3 mt-4">
+          <Link
+            className="border border-[#2FD8F6] bg-[#EAFBFE] hover:bg-[#E0F9FE] rounded-xl w-[140px] h-[45px] flex items-center justify-center text-[#2FD8F6]"
+            to="/signup"
+            state={{ presetRole: "참가자" }}
+          >
+            공모전 참여하기
+          </Link>
+          <Link
+            className="border rounded-xl bg-[#2FD8F6] hover:bg-[#2AC2DD] w-[140px] h-[45px] text-[#FFFFFF] flex items-center justify-center"
+            to="/signup"
+            state={{ presetRole: "소상공인" }}
+          >
+            도움 요청하기
+          </Link>
+        </div>
+        <Link
+          className="text-[#A3A3A3] underline text-sm"
+          to="/guest-main-page"
+        >
+          지금 올라온 공모전 둘러보기
+        </Link>
+      </div>
     </>
-  )
-}
+  );
+};
 
-export default Rending
+export default Rending;

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -9,6 +9,8 @@ import { BiSolidPencil } from "react-icons/bi";
 import MerchantBanner from "../main/MerchantBanner";
 import ParticipantHeader from "../header/ParticipantHeader";
 import ParticipantBanner from "../main/ParticipantBanner";
+import LoginRequiredModal from "../components/LoginRequiredModal"; // 🔹 추가
+import GuestHeader from "../header/GuestHeader";
 
 const SearchPage = () => {
   const [params, setParams] = useSearchParams();
@@ -16,13 +18,24 @@ const SearchPage = () => {
   const location = useLocation();
   const isMerchant = location.pathname.startsWith("/search");
 
-  const [activeTab, setActiveTab] = useState("IN_PROGRESS"); // 초기 미선택 = 전체
+  const [activeTab, setActiveTab] = useState("IN_PROGRESS");
   const [selectedCategories, setSelectedCategories] = useState([]);
   const [selectedBusinesses, setSelectedBusinesses] = useState([]);
   const [categories, setCategories] = useState([]);
   const [businessTypes, setBusinessTypes] = useState([]);
 
-  // q가 바뀌면 스크롤
+  const [showLoginModal, setShowLoginModal] = useState(false);
+
+  // role 설정 (경로 기반)
+  let role = "guest";
+  if (location.pathname.startsWith("/search")) {
+    role = "merchant";
+  } else if (location.pathname.startsWith("/participant-search")) {
+    role = "participant";
+  } else if (location.pathname.startsWith("/guest-search")) {
+    role = "guest";
+  }
+
   useEffect(() => {
     if (q) {
       document
@@ -38,8 +51,26 @@ const SearchPage = () => {
 
   return (
     <div>
-      {isMerchant ? <MerchantHeader /> : <ParticipantHeader />}
-      {isMerchant ? <MerchantBanner /> : <ParticipantBanner />}
+      {role === "merchant" && (
+        <>
+          <MerchantHeader />
+          <MerchantBanner />
+        </>
+      )}
+
+      {role === "participant" && (
+        <>
+          <ParticipantHeader />
+          <ParticipantBanner />
+        </>
+      )}
+
+      {role === "guest" && (
+        <>
+          <GuestHeader />
+          <MerchantBanner />
+        </>
+      )}
       {/* 상단 요약 바 */}
       <div
         id="search-title"
@@ -73,22 +104,34 @@ const SearchPage = () => {
             searchMode
             onClearSearch={onClearSearch}
             hideHeader
+            role={role}
+            onRequireLogin={() => setShowLoginModal(true)}
           />
         </div>
       </div>
       <Footer />
-      {isMerchant && (
+      {(role === "merchant" || role === "guest") && (
         <Link
-          to="/project-register"
+          to={role === "merchant" ? "/project-register" : "#"}
+          onClick={(e) => {
+            if (role === "guest") {
+              e.preventDefault();
+              setShowLoginModal(true);
+            }
+          }}
           className="fixed bottom-[50px] right-[110px] z-[9999]
-                  flex items-center gap-[6px] pl-[16px] pr-[20px] py-[12px] w-[157px] h-[45px]
-                  rounded-[8px] bg-[#2FD8F6] text-white hover:bg-[#2AC2DD] cursor-pointer"
+            flex items-center gap-[6px] pl-[16px] pr-[20px] py-[12px] w-[157px] h-[45px]
+            rounded-[8px] bg-[#2FD8F6] text-white hover:bg-[#2AC2DD] cursor-pointer"
         >
           <BiSolidPencil className="w-[16px] h-[16px]" />
           <span className="text-[16px] font-medium font-pretendard leading-[130%] tracking-[-0.02em]">
             공모전 등록하기
           </span>
         </Link>
+      )}
+
+      {showLoginModal && (
+        <LoginRequiredModal onClose={() => setShowLoginModal(false)} />
       )}
     </div>
   );


### PR DESCRIPTION
## 작업 개요

- 랜딩 페이지 - `지금 올라온 공모전 둘러보기` 클릭 -> 게스트 메인 화면 이동
- 게스트 헤더 구현 - `로그인/회원가입` 버튼 클릭 -> 로그인 화면 이동
- 공모전 목록, 카테고리/업종 필터, 상태 탭 기능 모두 소상공인/참가자와 동일하게 적용됨
- 공모전 카드, 공모전 등록하기 버튼, 내 공모전 클릭 시 로그인 후 이용해달라는 모달창 뜨게 함 
<img width="1882" height="890" alt="image" src="https://github.com/user-attachments/assets/124b3729-ba35-440e-a17b-fe70c35c45db" />

## 테스트 목록
- **로그인 하지 않은 상태로** `지금 올라온 공모전 둘러보기` 클릭 시 게스트 메인 화면, 게스트 헤더가 떠야함
- 공모전 카드, 공모전 등록하기 버튼, 내 공모전 클릭 시 모달창 떠야함
- 모달창에서 `로그인 하러가기` 버튼 클릭 시 -> 로그인 화면 이동
- 모달창에서 `회원가입` 클릭 시 -> 회원가입 화면 이동
- 모달창 X버튼 클릭시 -> 모달창 닫힘
- 검색창에 검색 후 나오는 공모전 목록의 카드를 클릭해도 모달창 떠야함
- **소상공인/참가자 로그인 후** 공모전 카드 클릭, 공모전 등록하기 버튼, 내 공모전, 검색시 공모전 카드 클릭 등은 원래대로 상세페이지, 등록 화면 등 정상적으로 떠야함
## 변경 사항

- #### `GuestMainPage.jsx` 추가 : 게스트 메인 페이지
- #### `LoginRequiredModal.jsx` 추가 : 로그인 후 이용할 수 있다는 모달창
- #### `ProjectList`, `ProjectCardInProgress`, `ProjectCardVoting`, `ProjectClosed` 등 컴포넌트에 guest 역할 조건 추가