### PR TITLE
Feature/searchpage-sort : 검색 후 나타나는 페이지에서 정렬 가능하도록 구현

### DIFF
--- a/src/main/ProjectList.jsx
+++ b/src/main/ProjectList.jsx
@@ -40,11 +40,19 @@ const ProjectList = ({
   hideHeader = false,
   role,
   onRequireLogin,
+  sortOption: propSortOption,
+  setSortOption: propSetSortOption,
 }) => {
   const [page, setPage] = useState(1);
   const [projects, setProjects] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [sortOption, setSortOption] = useState("최신순");
+
+  const [localSortOption, setLocalSortOption] = useState("최신순");
+
+  const sortOption =
+    propSortOption !== undefined ? propSortOption : localSortOption;
+  const setSortOption =
+    propSetSortOption !== undefined ? propSetSortOption : setLocalSortOption;
 
   useEffect(() => {
     setPage(1);
@@ -116,12 +124,12 @@ const ProjectList = ({
 
   return (
     <div className="flex flex-col gap-4 font-pretendard w-[856px]">
-      <div className="flex justify-between items-center mb-4 z-10">
-        {!hideHeader && activeTab && (
+      {!(isSearched || hideHeader) && activeTab && (
+        <div className="flex justify-between items-center mb-4 z-10">
           <h2 className="text-[20px] font-semibold">{headerText[activeTab]}</h2>
-        )}
-        <DropdownSort sortOption={sortOption} setSortOption={setSortOption} />
-      </div>
+          <DropdownSort sortOption={sortOption} setSortOption={setSortOption} />
+        </div>
+      )}
 
       {pageItems.length === 0 ? (
         emptyBySearch ? (

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -9,24 +9,24 @@ import { BiSolidPencil } from "react-icons/bi";
 import MerchantBanner from "../main/MerchantBanner";
 import ParticipantHeader from "../header/ParticipantHeader";
 import ParticipantBanner from "../main/ParticipantBanner";
-import LoginRequiredModal from "../components/LoginRequiredModal"; // 🔹 추가
+import LoginRequiredModal from "../components/LoginRequiredModal";
 import GuestHeader from "../header/GuestHeader";
+import DropdownSort from "../main/DropdownSort";
 
 const SearchPage = () => {
   const [params, setParams] = useSearchParams();
   const q = (params.get("q") ?? "").trim();
   const location = useLocation();
-  const isMerchant = location.pathname.startsWith("/search");
 
   const [activeTab, setActiveTab] = useState("IN_PROGRESS");
   const [selectedCategories, setSelectedCategories] = useState([]);
   const [selectedBusinesses, setSelectedBusinesses] = useState([]);
   const [categories, setCategories] = useState([]);
   const [businessTypes, setBusinessTypes] = useState([]);
+  const [sortOption, setSortOption] = useState("최신순");
 
   const [showLoginModal, setShowLoginModal] = useState(false);
 
-  // role 설정 (경로 기반)
   let role = "guest";
   if (location.pathname.startsWith("/search")) {
     role = "merchant";
@@ -57,29 +57,24 @@ const SearchPage = () => {
           <MerchantBanner />
         </>
       )}
-
       {role === "participant" && (
         <>
           <ParticipantHeader />
           <ParticipantBanner />
         </>
       )}
-
       {role === "guest" && (
         <>
           <GuestHeader />
           <MerchantBanner />
         </>
       )}
-      {/* 상단 요약 바 */}
       <div
         id="search-title"
         className="pt-[40px] pb-[28px] pl-[416px] font-pretendard text-[20px] text-[#212121] font-semibold"
       >
         {q ? <>‘{q}’ 검색 결과</> : <>검색어를 입력해 주세요</>}
       </div>
-
-      {/* 상태 탭(검색 전용 디자인) */}
       <div className="flex px-[240px] gap-[40px]" id="search-results">
         <CategoryFilter
           categories={categories}
@@ -91,8 +86,17 @@ const SearchPage = () => {
           selectedBusinesses={selectedBusinesses}
           setSelectedBusinesses={setSelectedBusinesses}
         />
-        <div>
-          <SearchStatusTabs activeTab={activeTab} setActiveTab={setActiveTab} />
+        <div className="flex-1">
+          <div className="flex flex-row justify-between items-center mb-4">
+            <SearchStatusTabs
+              activeTab={activeTab}
+              setActiveTab={setActiveTab}
+            />
+            <DropdownSort
+              sortOption={sortOption}
+              setSortOption={setSortOption}
+            />
+          </div>
           <ProjectList
             q={q}
             isSearched={!!q}
@@ -103,9 +107,11 @@ const SearchPage = () => {
             selectedBusinesses={selectedBusinesses}
             searchMode
             onClearSearch={onClearSearch}
-            hideHeader
+            hideHeader={true}
             role={role}
             onRequireLogin={() => setShowLoginModal(true)}
+            sortOption={sortOption}
+            setSortOption={setSortOption}
           />
         </div>
       </div>


### PR DESCRIPTION
## 작업 개요

- 검색 후 나타나는 페이지에서 정렬 가능하도록 구현

## 변경 사항

**드롭다운 위치 변경**
<img width="1512" height="825" alt="스크린샷 2025-08-22 오후 8 05 49" src="https://github.com/user-attachments/assets/4c3d330a-2adc-402a-9fb9-1ee0b1ee77c4" />

**최신순으로 나열**
<img width="1512" height="821" alt="스크린샷 2025-08-22 오후 8 06 00" src="https://github.com/user-attachments/assets/5a2f5b91-90f9-442e-b074-e9d2c064720b" />

**총상금순으로 나열**
<img width="1512" height="821" alt="스크린샷 2025-08-22 오후 8 06 09" src="https://github.com/user-attachments/assets/900da550-3b5b-4952-b094-978183bb05f7" />


## 관련 이슈

- (관련 이슈 번호나 링크를 작성하세요)
