### PR TITLE
fix: 게스트 메인 화면 진입 오류 수정

### DIFF
--- a/src/apis/api.jsx
+++ b/src/apis/api.jsx
@@ -5,8 +5,6 @@ const api = axios.create({
   withCredentials: true,
 });
 
-
-
 api.interceptors.request.use(
   (config) => {
     const accessToken = sessionStorage.getItem("accessToken");
@@ -28,8 +26,11 @@ api.interceptors.response.use(
   },
   async (error) => {
     if (error.response.status === 401) {
-      sessionStorage.clear();
-      window.location.href = "/signin";
+      const currentPath = window.location.pathname;
+      if (currentPath !== "/guest-main-page") {
+        sessionStorage.clear();
+        window.location.href = "/signin";
+      }
     }
     return Promise.reject(error);
   }


### PR DESCRIPTION
## 변경 사항
- 문제 : 게스트는 토큰이 없어서 공모전 목록 진입했을 때 401 에러 떠서 로그인 페이지로 강제 리다이렉트 되는 문제 발생
- guest-main-page 경로에서는 리다이렉트 되지 않도록 api.jsx 파일 수정
