### PR TITLE
fix: 잘못된 projectId로 상세페이지에 접근하는 경우 역할별 리다이렉트

### DIFF
--- a/src/pages/ProjectDetail.jsx
+++ b/src/pages/ProjectDetail.jsx
@@ -79,6 +79,8 @@ const ProjectDetail = ({ role }) => {
         setUserInfo(data);
       } catch (err) {
         console.error("사용자 정보 불러오기 실패:", err);
+        setUserInfo({ role: "ROLE_GUEST" });
+        setLoading(false);
       }
     };
     loadUserInfo();
@@ -86,6 +88,8 @@ const ProjectDetail = ({ role }) => {
 
   useEffect(() => {
     if (!userInfo) return;
+    if (userInfo.role === "ROLE_GUEST") return;
+
     const fetchProjectDetails = async () => {
       try {
         setLoading(true);
@@ -104,8 +108,6 @@ const ProjectDetail = ({ role }) => {
             navigate("/merchant-main-page");
           } else if (userInfo?.role === "ROLE_USER") {
             navigate("/participant-main-page");
-          } else {
-            navigate("/guest-main-page");
           }
         } else {
           alert("프로젝트 정보를 불러오는 데 실패했습니다.");
@@ -113,8 +115,6 @@ const ProjectDetail = ({ role }) => {
             navigate("/merchant-main-page");
           } else if (userInfo?.role === "ROLE_USER") {
             navigate("/participant-main-page");
-          } else {
-            navigate("/guest-main-page");
           }
         }
         setProjectData(null);
@@ -125,6 +125,15 @@ const ProjectDetail = ({ role }) => {
 
     fetchProjectDetails();
   }, [projectId, location.state?.refresh, userInfo]);
+
+  useEffect(() => {
+    if (userInfo === null) return;
+
+    if (userInfo.role === "ROLE_GUEST") {
+      alert("로그인이 필요한 서비스입니다.");
+      navigate("/signin");
+    }
+  }, [userInfo, navigate]);
 
   const winnerIdFromServer = deriveWinnerId(projectData, submissions);
 


### PR DESCRIPTION
## 작업 개요

- 잘못된 projectId로 상세페이지에 접근하는 경우 역할별 리다이렉트 적용

## 변경 사항
- `소상공인`으로 로그인한 상태에서 잘못된 projectId로 상세페이지 접근 시 `소상공인 메인 페이지`로 리다이렉트
- `참가자`로 로그인한 상태에서 잘못된 projectId로 상세페이지 접근 시 `참가자 메인 페이지`로 리다이렉트
- `게스트`는 상세페이지에 접근할 수 없으므로 로그인 필요 알림창 + `로그인 페이지`로 리다이렉트
```jsx
if (err?.response?.status === 404) {
  alert("해당 프로젝트를 찾을 수 없습니다.");
  if (userInfo?.role === "ROLE_BUSINESS") {
    navigate("/merchant-main-page");
  } else if (userInfo?.role === "ROLE_USER") {
    navigate("/participant-main-page");
  }
}
```
```jsx
useEffect(() => {
  if (userInfo === null) return;

  if (userInfo.role === "ROLE_GUEST") {
    alert("로그인이 필요한 서비스입니다.");
    navigate("/signin");
  }
}, [userInfo, navigate]);
```
