### PR TITLE
Fix/page-access-role : 역할별 메인 페이지 접근 제한 추가

### DIFF
--- a/src/pages/GuestMainPage.jsx
+++ b/src/pages/GuestMainPage.jsx
@@ -7,8 +7,11 @@ import Footer from "../components/Footer";
 import MerchantBanner from "../main/MerchantBanner";
 import GuestHeader from "../header/GuestHeader";
 import LoginRequiredModal from "../components/LoginRequiredModal";
+import { fetchUserInfo } from "../apis/userApi";
+import { useNavigate } from "react-router-dom";
 
 const GuestMainPage = () => {
+  const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState("IN_PROGRESS");
   const [selectedCategories, setSelectedCategories] = useState([]);
   const [selectedBusinesses, setSelectedBusinesses] = useState([]);
@@ -22,6 +25,29 @@ const GuestMainPage = () => {
     setSelectedCategories([]);
     setSelectedBusinesses([]);
   }, [activeTab]);
+
+  useEffect(() => {
+    const checkIfLoggedIn = async () => {
+      try {
+        const user = await fetchUserInfo();
+        if (user?.role === "ROLE_USER") {
+          alert(
+            "참가자 계정으로 로그인된 상태입니다.\n참가자 메인 페이지로 이동합니다."
+          );
+          navigate("/participant-main-page");
+        } else if (user?.role === "ROLE_BUSINESS") {
+          alert(
+            "소상공인 계정으로 로그인된 상태입니다.\n소상공인 메인 페이지로 이동합니다."
+          );
+          navigate("/merchant-main-page");
+        }
+      } catch (err) {
+        console.log("게스트 접근 허용");
+      }
+    };
+
+    checkIfLoggedIn();
+  }, [navigate]);
 
   return (
     <div>

--- a/src/pages/MerchantMainPage.jsx
+++ b/src/pages/MerchantMainPage.jsx
@@ -29,7 +29,7 @@ const MerchantMainPage = () => {
       try {
         const user = await fetchUserInfo();
         if (user.role !== "ROLE_BUSINESS") {
-          alert("접근 권한이 없습니다.");
+          alert("소상공인 계정으로 로그인해야 이용할 수 있습니다.");
           navigate("/participant-main-page");
         }
       } catch (err) {

--- a/src/pages/MerchantMainPage.jsx
+++ b/src/pages/MerchantMainPage.jsx
@@ -33,7 +33,7 @@ const MerchantMainPage = () => {
           navigate("/participant-main-page");
         }
       } catch (err) {
-        console.error("권한 확인 실패:", err);
+        alert("소상공인 계정으로 로그인해야 이용할 수 있습니다.");
         navigate("/signin");
       }
     };

--- a/src/pages/MerchantMainPage.jsx
+++ b/src/pages/MerchantMainPage.jsx
@@ -4,11 +4,13 @@ import ProjectStatusTabs from "../main/ProjectStatusTabs";
 import CategoryFilter from "../main/CategoryFilter";
 import ProjectList from "../main/ProjectList";
 import { BiSolidPencil } from "react-icons/bi";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import Footer from "../components/Footer";
 import MerchantBanner from "../main/MerchantBanner";
+import { fetchUserInfo } from "../apis/userApi";
 
 const MerchantMainPage = () => {
+  const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState("CLOSED"); // 진행중, 투표중, 완료 탭 상태
   const [selectedCategories, setSelectedCategories] = useState([]); // 카테고리 선택 상태
   const [selectedBusinesses, setSelectedBusinesses] = useState([]); // 업종 선택 상태
@@ -21,6 +23,23 @@ const MerchantMainPage = () => {
     setSelectedCategories([]);
     setSelectedBusinesses([]);
   }, [activeTab]);
+
+  useEffect(() => {
+    const checkRole = async () => {
+      try {
+        const user = await fetchUserInfo();
+        if (user.role !== "ROLE_BUSINESS") {
+          alert("접근 권한이 없습니다.");
+          navigate("/participant-main-page");
+        }
+      } catch (err) {
+        console.error("권한 확인 실패:", err);
+        navigate("/signin");
+      }
+    };
+
+    checkRole();
+  }, [navigate]);
 
   return (
     <div>

--- a/src/pages/ParticipantMainPage.jsx
+++ b/src/pages/ParticipantMainPage.jsx
@@ -28,7 +28,7 @@ const ParticipantMainPage = () => {
       try {
         const user = await fetchUserInfo();
         if (user.role !== "ROLE_USER") {
-          alert("접근 권한이 없습니다.");
+          alert("참가자 계정으로 로그인해야 이용할 수 있습니다.");
           navigate("/merchant-main-page");
         }
       } catch (err) {

--- a/src/pages/ParticipantMainPage.jsx
+++ b/src/pages/ParticipantMainPage.jsx
@@ -32,7 +32,7 @@ const ParticipantMainPage = () => {
           navigate("/merchant-main-page");
         }
       } catch (err) {
-        console.error("권한 확인 실패:", err);
+        alert("참가자 계정으로 로그인해야 이용할 수 있습니다.");
         navigate("/signin");
       }
     };

--- a/src/pages/ParticipantMainPage.jsx
+++ b/src/pages/ParticipantMainPage.jsx
@@ -5,8 +5,11 @@ import ProjectList from "../main/ProjectList";
 import Footer from "../components/Footer";
 import ParticipantHeader from "../header/ParticipantHeader";
 import ParticipantBanner from "../main/ParticipantBanner";
+import { fetchUserInfo } from "../apis/userApi";
+import { useNavigate } from "react-router-dom";
 
 const ParticipantMainPage = () => {
+  const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState("IN_PROGRESS"); // 진행중, 투표중, 완료 탭 상태 / 참가자 기본값 : 진행중
   const [selectedCategories, setSelectedCategories] = useState([]); // 카테고리 선택 상태
   const [selectedBusinesses, setSelectedBusinesses] = useState([]); // 업종 선택 상태
@@ -19,6 +22,23 @@ const ParticipantMainPage = () => {
     setSelectedCategories([]);
     setSelectedBusinesses([]);
   }, [activeTab]);
+
+  useEffect(() => {
+    const checkRole = async () => {
+      try {
+        const user = await fetchUserInfo();
+        if (user.role !== "ROLE_USER") {
+          alert("접근 권한이 없습니다.");
+          navigate("/merchant-main-page");
+        }
+      } catch (err) {
+        console.error("권한 확인 실패:", err);
+        navigate("/signin");
+      }
+    };
+
+    checkRole();
+  }, [navigate]);
 
   return (
     <div>


### PR DESCRIPTION
## 변경 사항

#### 소상공인 메인 페이지
- `참가자` 계정으로 접근 시 -> "소상공인 계정으로 로그인해야 이용할 수 있습니다." 알림 후 **참가자 메인 페이지**로 이동
- `게스트`로 접근 시 -> "소상공인 계정으로 로그인해야 이용할 수 있습니다." 알림 후 **로그인 페이지**로 이동

#### 참가자 메인 페이지
- `소상공인` 계정으로 접근 시 -> "참가자 계정으로 로그인해야 이용할 수 있습니다." 알림 후 **소상공인 메인 페이지**로 이동
- `게스트`로 접근 시 -> "참가자 계정으로 로그인해야 이용할 수 있습니다." 알림 후 **로그인 페이지**로 이동

#### 게스트 메인 페이지
- `소상공인` 계정으로 접근 시 -> "소상공인 계정으로 로그인된 상태입니다. 소상공인 메인 페이지로 이동합니다." 알림 후 **소상공인 메인 페이지**로 이동
- `참가자` 계정으로 접근 시 -> "참가자 계정으로 로그인된 상태입니다. 참가자 메인 페이지로 이동합니다." 알림 후 **참가자 메인 페이지**로 이동
