### PR TITLE
fix: 공모전 상금 직접 입력 후 등록 시,  0 세 개가 빠지는 오류 수정

### DIFF
--- a/src/pages/ProjectRegister.jsx
+++ b/src/pages/ProjectRegister.jsx
@@ -437,7 +437,7 @@ const ProjectRegister = () => {
       description: aiProjectData.description,
       createdAt: createdAt,
       deadline: aiProjectData.deadline,
-      rewardAmount: parseInt(aiProjectData.rewardAmount, 10),
+      rewardAmount: parseInt(aiProjectData.rewardAmount.replace(/,/g, ""), 10),
       summary: aiProjectData.summary,
       colors: colors.length > 0 && !colors.includes("color_free") ? colors : [],
       styles: styles.length > 0 && !styles.includes("style_free") ? styles : [],


### PR DESCRIPTION
## 변경 사항

- 공모전 상금 직접 입력 후 등록 시,  0 세 개가 빠지는 오류 수정
- 150,000원 입력시, 150원으로 등록되는 문제였음
